### PR TITLE
feat: unoptimized images

### DIFF
--- a/components/team/TeamSection.tsx
+++ b/components/team/TeamSection.tsx
@@ -110,6 +110,7 @@ function TeamCard({ member, delay }: { member: TeamMember; delay: number }) {
                                     height={80}
                                     onError={() => setImgError(true)}
                                     className="w-full h-full object-cover object-center"
+                                    unoptimized
                                 />
                             ) : (
                                 <span className="font-[var(--font-space-grotesk)] font-bold text-2xl text-[#EEF0F7]">


### PR DESCRIPTION
## Summary
This pull request makes a minor update to the `TeamSection.tsx` component. The change ensures that the team member images are rendered without Next.js image optimization.

* Added the `unoptimized` prop to the `Image` component to disable automatic image optimization for team member photos.